### PR TITLE
add: createTodo adds uuid to todoItemWrapper

### DIFF
--- a/todo.js
+++ b/todo.js
@@ -104,6 +104,9 @@ function createTodo() {
     todoItem.appendChild(doneButton);
     todoItem.appendChild(todoContent);
     todoItem.appendChild(deleteButton);
+    
+    // add uuid to todoItemWrapper
+    todoItemWrapper.id = todos?.at(-1).id;
     input.value = '';
 }
 
@@ -112,6 +115,8 @@ function createTodo() {
  * @returns {void}
  */
 function deleteTodo() {
+    // addEventListenerでon_clickで発火するように、ここで、現在のid属性を取得すればok
+    // wrapperclass の delete_buttonのidを取得する。
     console.log("deleteTodo!");
 }
 


### PR DESCRIPTION
[add]
`create_todo`関数でuuidを`todoItemWrapper`のid属性に追加しました。

[理由]
`delete_todo`関数と`done_todo`関数で個別のTodoを指定する必要が出てきたため

```js
// add uuid to todoItemWrapper
todoItemWrapper.id = todos?.at(-1).id;
```

![image](https://github.com/WATA-Haru/todo/assets/43723360/b245ded9-157b-430a-b15f-a1d29f3d5112)
